### PR TITLE
dev(shuffle): add shuffle feature into timing mode of commands

### DIFF
--- a/pji/control/run/timing.py
+++ b/pji/control/run/timing.py
@@ -1,5 +1,7 @@
 import io
+import random
 import time
+from itertools import chain
 
 from .encoding import _try_write, _try_read_to_bytes
 from ..model import RunResult
@@ -7,9 +9,31 @@ from ..model import TimingContent as _AbstractTimingContent
 from ..process import interactive_process
 from ...utils import eclosing
 
+_STDIN_SHUFFLE_EPS = 1e-4
+
 
 class TimingStdin(_AbstractTimingContent):
-    pass
+    def to_shuffled(self):
+        groups = []
+        current_group = []
+        for ftime, content in self.lines:
+            if current_group:
+                if abs(ftime - current_group[0][0]) < _STDIN_SHUFFLE_EPS:
+                    current_group.append((ftime, content))
+                else:
+                    groups.append(current_group)
+                    current_group = [(ftime, content)]
+            else:
+                current_group.append((ftime, content))
+
+        if current_group:
+            groups.append(current_group)
+
+        for group in groups:
+            random.shuffle(group)
+
+        final_items = list(chain(*(group for group in groups)))
+        return self.__class__(final_items)
 
 
 class TimingStdout(_AbstractTimingContent):
@@ -21,7 +45,7 @@ class TimingStderr(_AbstractTimingContent):
 
 
 def timing_run(args, shell: bool = False, stdin=None, stdout=None, stderr=None,
-               environ=None, cwd=None, resources=None, identification=None) -> RunResult:
+               environ=None, cwd=None, resources=None, identification=None, shuffle=False) -> RunResult:
     """
     Create an timing process with stream
     :param args: arguments for execution
@@ -33,6 +57,7 @@ def timing_run(args, shell: bool = False, stdin=None, stdout=None, stderr=None,
     :param cwd: new work dir
     :param resources: resource limit
     :param identification: user and group for execution
+    :param shuffle: Shuffle the inputs with similar timestamp.
     :return: run result of this time
     """
     stdin_need_close = not stdin
@@ -47,12 +72,15 @@ def timing_run(args, shell: bool = False, stdin=None, stdout=None, stderr=None,
     with eclosing(stdin, stdin_need_close) as stdin, \
             eclosing(stdout, stdout_need_close) as stdout, \
             eclosing(stderr, stderr_need_close) as stderr:
+        _stdin = TimingStdin.loads(_try_read_to_bytes(stdin))
+        if shuffle:
+            _stdin = _stdin.to_shuffled()
+
         with interactive_process(
                 args=args, shell=shell,
                 environ=environ, cwd=cwd,
                 resources=resources, identification=identification,
         ) as ip:
-            _stdin = TimingStdin.loads(_try_read_to_bytes(stdin))
             for _time, _line in _stdin.lines:
                 _target_time = ip.start_time + _time
                 while time.time() < _target_time and not ip.completed:
@@ -72,7 +100,7 @@ def timing_run(args, shell: bool = False, stdin=None, stdout=None, stderr=None,
                 elif _tag == 'stderr':
                     _stderr.append((_time, _line))
                 else:
-                    raise ValueError('Unknown output type - {type}.'.format(type=repr(_time)))
+                    raise ValueError('Unknown output type - {type}.'.format(type=repr(_time)))  # pragma: no cover
 
             ip.join()
             _try_write(stdout, TimingStdout.loads(_stdout).dumps())

--- a/pji/service/command/base.py
+++ b/pji/service/command/base.py
@@ -46,7 +46,7 @@ ENV_PJI_COMMAND_INDEX = 'PJI_COMMAND_INDEX'
 
 class _ICommandBase:
     def __init__(self, args: Union[str, List[str]], shell: bool = True, workdir: Optional[str] = None,
-                 identification=None, resources=None, mode=None):
+                 identification=None, resources=None, mode=None, **kwargs):
         """
         :param args: arguments
         :param shell: use shell mode
@@ -61,6 +61,7 @@ class _ICommandBase:
         self.__identification = identification
         self.__resources = resources
         self.__mode = mode
+        self.__kwargs = kwargs
 
     def __repr__(self):
         """
@@ -79,5 +80,6 @@ class _ICommandBase:
                  lambda: self.__identification and self.__identification != Identification.loads({})),
                 ('resources', lambda: truncate(repr(self.__resources), width=64, show_length=True, tail_length=16),
                  lambda: self.__resources and self.__resources != ResourceLimit.loads({})),
+                *[(key, lambda: repr(value)) for key, value in self.__kwargs.items()]
             ]
         )

--- a/pji/service/command/command.py
+++ b/pji/service/command/command.py
@@ -12,7 +12,7 @@ class Command(_ICommandBase):
     def __init__(self, args: Union[str, List[str]], shell: bool,
                  workdir: Optional[str], environ: Mapping[str, str],
                  identification: Identification, resources: ResourceLimit,
-                 mode, stdin, stdout, stderr):
+                 mode, stdin, stdout, stderr, **kwargs):
         """
         :param args: arguments
         :param shell: use shell mode
@@ -39,8 +39,9 @@ class Command(_ICommandBase):
         self.__stdout = env_template(stdout, self.__environ) if isinstance(stdout, str) else stdout
         self.__stderr = env_template(stderr, self.__environ) if isinstance(stderr, str) else stderr
 
+        self.__kwargs = kwargs
         _ICommandBase.__init__(self, self.__args, self.__shell, self.__workdir,
-                               self.__identification, self.__resources, self.__mode)
+                               self.__identification, self.__resources, self.__mode, **kwargs)
 
     @property
     def args(self) -> Union[str, List[str]]:
@@ -81,6 +82,10 @@ class Command(_ICommandBase):
     @property
     def stderr(self):
         return self.__stderr
+
+    @property
+    def kwargs(self):
+        return self.__kwargs
 
     __RUN_FUNCTION = {
         CommandMode.COMMON: common_run,
@@ -124,6 +129,7 @@ class Command(_ICommandBase):
                 stdin=fstdin, stdout=fstdout, stderr=fstderr,
                 environ=self.__environ, cwd=self.__workdir,
                 resources=self.__resources, identification=self.__identification,
+                **self.__kwargs,
             )
 
         wrap_empty(command_complete)(self, _result)

--- a/pji/service/command/template.py
+++ b/pji/service/command/template.py
@@ -129,7 +129,7 @@ class CommandTemplate(_ICommandBase):
             identification=_identification, resources=_resources,
             mode=self.__mode, stdin=_stdin, stdout=_stdout, stderr=_stderr,
             **{
-                key: env_template(value, environ)
+                key: env_template(value, environ) if isinstance(value, str) else value
                 for key, value in self.__kwargs.items()
             }
         )

--- a/pji/service/command/template.py
+++ b/pji/service/command/template.py
@@ -15,7 +15,7 @@ class CommandTemplate(_ICommandBase):
 
     def __init__(self, args: Union[str, List[str]], shell: bool = True,
                  workdir: Optional[str] = None, resources=None,
-                 mode=None, stdin=None, stdout=None, stderr=None):
+                 mode=None, stdin=None, stdout=None, stderr=None, **kwargs):
         """
         :param args: arguments
         :param shell: use shell mode
@@ -42,8 +42,9 @@ class CommandTemplate(_ICommandBase):
         self.__stdout = stdout
         self.__stderr = stderr
 
+        self.__kwargs = kwargs
         _ICommandBase.__init__(self, self.__args, self.__shell, self.__workdir,
-                               None, self.__resources, self.__mode)
+                               None, self.__resources, self.__mode, **self.__kwargs)
 
     @property
     def args(self) -> Union[str, List[str]]:
@@ -127,6 +128,10 @@ class CommandTemplate(_ICommandBase):
             workdir=_workdir, environ=environ,
             identification=_identification, resources=_resources,
             mode=self.__mode, stdin=_stdin, stdout=_stdout, stderr=_stderr,
+            **{
+                key: env_template(value, environ)
+                for key, value in self.__kwargs.items()
+            }
         )
 
     @classmethod

--- a/test/control/run/test_timing.py
+++ b/test/control/run/test_timing.py
@@ -4,12 +4,48 @@ from contextlib import closing
 import pytest
 
 from pji.control.model import RunResultStatus
-from pji.control.run import timing_run, TimingStdout, TimingStderr
+from pji.control.run import timing_run, TimingStdout, TimingStderr, TimingStdin
 
 
 # noinspection DuplicatedCode
 @pytest.mark.unittest
 class TestControlRunTiming:
+    def test_timing_stdin(self):
+        _stdin = b"""
+[0.0]echo 233
+[0.0]echo 2334
+[0.1]whoami
+        """
+
+        with closing(io.BytesIO(_stdin)) as stdin:
+            si = TimingStdin.load(stdin)
+            assert si.str_lines == [
+                (0.0, 'echo 233'),
+                (0.0, 'echo 2334'),
+                (0.1, 'whoami'),
+            ]
+
+            order, unorder = False, False
+            for i in range(100):
+                ssi = si.to_shuffled()
+                assert isinstance(ssi, TimingStdin)
+                if ssi.str_lines == [
+                    (0.0, 'echo 233'),
+                    (0.0, 'echo 2334'),
+                    (0.1, 'whoami'),
+                ]:
+                    order = True
+                elif ssi.str_lines == [
+                    (0.0, 'echo 2334'),
+                    (0.0, 'echo 233'),
+                    (0.1, 'whoami'),
+                ]:
+                    unorder = True
+                else:
+                    pytest.fail('Should not reach here.')
+
+            assert order and unorder
+
     def test_simple(self):
         _stdin = b"""
 [0.0]echo 233
@@ -67,6 +103,49 @@ class TestControlRunTiming:
             assert result.ok
             assert result.completed
             assert result.status == RunResultStatus.SUCCESS
+
+    def test_simple_with_shuffle(self):
+        _stdin = """
+[0.0]echo 233
+[0.0]echo 2334
+[0.1]whoami
+            """
+        order, unorder = False, False
+        for i in range(20):
+            if order and unorder:
+                break
+
+            with closing(io.StringIO(_stdin)) as stdin, \
+                    closing(io.StringIO()) as stdout, closing(io.StringIO()) as stderr:
+                result = timing_run(
+                    args='sh', identification='nobody',
+                    stdin=stdin, stdout=stdout, stderr=stderr,
+                    shuffle=True,
+                )
+
+                _stdout = TimingStdout.loads(stdout.getvalue())
+                assert len(_stdout.lines) == 3
+                assert _stdout.lines[0][0] <= _stdout.lines[1][0] <= _stdout.lines[2][0]
+
+                if (0 <= _stdout.lines[0][0] <= 0.3 and _stdout.lines[0][1].rstrip(b'\r\n') == b'233') and \
+                        (0 <= _stdout.lines[1][0] <= 0.3 and _stdout.lines[1][1].rstrip(b'\r\n') == b'2334'):
+                    order = True
+                elif (0 <= _stdout.lines[0][0] <= 0.3 and _stdout.lines[0][1].rstrip(b'\r\n') == b'2334') and \
+                        (0 <= _stdout.lines[1][0] <= 0.3 and _stdout.lines[1][1].rstrip(b'\r\n') == b'233'):
+                    unorder = True
+                else:
+                    pytest.fail('Should not reach here.')
+
+                assert 0.1 <= _stdout.lines[2][0] <= 0.5
+                assert _stdout.lines[2][1].rstrip(b'\r\n') == b'nobody'
+
+                assert stderr.getvalue().rstrip('\r\n') == ''
+
+                assert result.ok
+                assert result.completed
+                assert result.status == RunResultStatus.SUCCESS
+
+        assert order and unorder
 
     def test_with_stderr(self):
         with closing(io.BytesIO()) as stdout, closing(io.BytesIO()) as stderr:


### PR DESCRIPTION
Like this

- `test_script.yml`

```yml
global:
  environ:
  use_sys_env:
    - PATH
    - LC_ALL
    - LANG
tasks:
  main:
    sections:
      - name: run_it
        inputs:
          - "copy:test_input.txt:test_input.txt"
        outputs:
          - "copy:test_output.txt:test_output.txt"
        commands:
          - args: "/bin/bash"
            mode: timing
            stdin: test_input.txt
            stdout: test_output.txt
            shuffle: true
```

- `test_input.txt`

```
[0.0]echo 233
[0.0]echo 2334
[0.0]echo 23345
[0.1]echo 233456
```

